### PR TITLE
Stopwatch limit

### DIFF
--- a/Firmware/Chronograph.ino
+++ b/Firmware/Chronograph.ino
@@ -16,7 +16,7 @@
 
 Version:        1.2.0
 Modified:       October 2, 2017
-Verified:
+Verified:       October 3, 2017
 Target uC:      ATtiny85
 
 -----------------------------------------***DESCRIPTION***

--- a/Firmware/Chronograph.ino
+++ b/Firmware/Chronograph.ino
@@ -15,8 +15,8 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 Version:        1.2.0
-Modified:       September 27, 2017
-Verified:       September 27, 2017
+Modified:       October 2, 2017
+Verified:
 Target uC:      ATtiny85
 
 -----------------------------------------***DESCRIPTION***
@@ -48,6 +48,7 @@ int debounce = 40UL;            //debounce time in milliseconds
 //unsigned long prevTime = 0;
 byte SQWstate;
 
+byte swHrs = 0;                 //stores the hours value of the stopwatch
 byte swMin = 0;                 //stores the minutes value of the stopwatch
 byte swSec = 0;                 //stores the seconds value of the stopwatch
 boolean runSW = false;          //trigger for incrementing the stopwatch in the main loop
@@ -191,13 +192,24 @@ bailout:
   {
     swSec = ++swSec;                                //increment the stopwatch seconds
     if(swSec > 59) {swSec = 0; swMin = ++swMin;}    //change the seconds to zero if the value passes 59
-    writeLeft(swMin);                               //refresh the display
-    writeRight(swSec);                              //"
-    if((swSec == 0) && (swMin == 90))               //if the stopwatch reaches 90 minutes and 0 seconds
+    if(swMin > 59) {swMin = 0; swHrs = ++swHrs;}    //change the minutes to zero if the value passes 59
+    if(swHrs == 0)
+    {
+      writeLeft(swMin);                             //refresh the display
+      writeRight(swSec);                            //"
+    }
+    if(swHrs > 0)
+    {
+      drawColon = !drawColon;                       //toggle the colon every second if an hour has passed
+      writeLeft(swHrs);                             //refresh the display
+      writeRight(swMin);                            //"
+    }
+    if(swHrs == 99)                                 //if the stopwatch reaches 99 hours
     {
       runSW = false;                                //disable the stopwatch
       swSec = 0;                                    //reset the stopwatch seconds value
       swMin = 0;                                    //reset the stopwatch minutes value
+      swHrs = 0;                                    //reset the stopwatch hours value
       menu = B00001010;
     }
   }

--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@ This is the codebase for the Chronograph project, by DS Guitar Engineering.  The
 
 ## Getting Started
 
-Follow these instructions to build a Chronograph development board.  See the depolyment section if you wish to use the official Chronograph hardware for development.
+Follow these instructions to build a Chronograph development board.  See the deployment section if you wish to use the official Chronograph hardware for development.
 
 ### Prerequisites
 
-The following is a minimum BOM needed to make a Chronograph development board.  Links are provided for the DIP variant (if available) for simplified breadboard wiring.  The official hardware utilizies 100% surface mount packages.
+The following is a minimum BOM needed to make a Chronograph development board.  Links are provided for the DIP variant (if available) for simplified breadboard wiring.  The official hardware utilizes 100% surface mount packages.
 * Any [ATtiny85](http://www.mouser.com/ProductDetail/Microchip-Technology-Atmel/ATtiny85-20PU/?qs=sGAEpiMZZMtkfMPOFRTOl5CRAVRAdtfp) variant
 * Any variant of the [DS1307](http://www.mouser.com/ProductDetail/Maxim-Integrated/DS1307+/?qs=sGAEpiMZZMsWkX3fPoxIPao0OKuDwxf4) RTC
 * [AS1115](http://www.mouser.com/Search/ProductDetail.aspx?R=AS1115-BSSTvirtualkey58040000virtualkey985-AS1115-BSST) display driver
@@ -54,7 +54,7 @@ Please initiate contact through our [official website](https://ds.engineering/co
 
 ## Versioning
 
-We use [SemVer](http://semver.org/) for versioning. For the versions available, see the [tags on this repository](https://github.com/DSGuitarEngineering/Chronograph/tags). 
+We use [SemVer](http://semver.org/) for versioning. For the versions available, see the [tags on this repository](https://github.com/DSGuitarEngineering/Chronograph/tags).
 
 ## Authors
 


### PR DESCRIPTION
The stopwatch limit was raised from its previous limit of 90 minutes to 99 hours.  New code was written to convert the display from "mm:ss" to "hh:mm" at the 60 minute mark.  The colon also begins to blink at this point to indicate the stopwatch is still running.  This avoids confusion by differentiating from the look of the clock mode.

Closes #3 